### PR TITLE
News defaults

### DIFF
--- a/modules/stanford_news_helper/stanford_news_helper.info.yml
+++ b/modules/stanford_news_helper/stanford_news_helper.info.yml
@@ -1,0 +1,7 @@
+name: Stanford News Helper
+type: module
+description: Helper functionality for Stanford News
+core: 8.x
+package: Stanford Earth
+dependencies:
+  - stanford_paragraph_types

--- a/modules/stanford_news_helper/stanford_news_helper.info.yml
+++ b/modules/stanford_news_helper/stanford_news_helper.info.yml
@@ -2,6 +2,7 @@ name: Stanford News Helper
 type: module
 description: Helper functionality for Stanford News
 core: 8.x
+version: 8.x-1.0-dev
 package: Stanford Earth
 dependencies:
   - stanford_paragraph_types

--- a/modules/stanford_news_helper/stanford_news_helper.module
+++ b/modules/stanford_news_helper/stanford_news_helper.module
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * stanford_news_helper.module
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_news_helper_form_node_stanford_news_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_state->getFormObject()->getEntity()->isNew()) {
+    $subform = &$form['field_s_news_media_contacts']['widget'][0]['subform'];
+    $subform['field_highlight_cards_title']['widget'][0]['value']['#default_value'] = 'Media Contacts';
+  }
+}

--- a/modules/stanford_news_helper/stanford_news_helper.module
+++ b/modules/stanford_news_helper/stanford_news_helper.module
@@ -14,5 +14,9 @@ function stanford_news_helper_form_node_stanford_news_form_alter(&$form, FormSta
   if ($form_state->getFormObject()->getEntity()->isNew()) {
     $subform = &$form['field_s_news_media_contacts']['widget'][0]['subform'];
     $subform['field_highlight_cards_title']['widget'][0]['value']['#default_value'] = 'Media Contacts';
+    $card_subform = &$subform['field_p_section_highlight_cards']['widget'][0]['subform'];
+    $card_subform['field_p_highlight_card_title']['widget'][0]['value']['#default_value'] = 'Ker Than';
+    $card_subform['field_p_highlight_card_subtitle']['widget'][0]['value']['#default_value'] = '650-723-9820';
+    $card_subform['field_p_highlight_card_desc']['widget'][0]['value']['#default_value'] = 'kerthan@stanford.edu';
   }
 }

--- a/modules/stanford_paragraph_options/stanford_paragraph_options.module
+++ b/modules/stanford_paragraph_options/stanford_paragraph_options.module
@@ -24,7 +24,6 @@ function stanford_paragraph_options_help($route_name, RouteMatchInterface $route
   }
 }
 
-
 /**
  * Implements hook_form_FORM_ID_alter().
  */


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Default content for media contacts in stanford news.

# Needed By (Date)
- soon

# Urgency
- high

# Steps to Test

1. checkout branch.
2. enable stanford_news_helper
3. create new news content.
4. verify the media contacts fields are prepopulated.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)