### PR TITLE
EARTH-633: Adding a space after prof's name

### DIFF
--- a/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
+++ b/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
@@ -80,7 +80,7 @@ class MosaicBlockDefault extends BlockBase {
             'title' => 'Students',
           ],
           [
-            'cite_name' => $this->t('Biondo Biondi.'),
+            'cite_name' => $this->t('Biondo Biondi. '),
             'cite_title' => $this->t('Geophysics Professor.'),
             'classes' => 'photo-mosaic--thumbs-up',
             'description' => $this->t('We discover and teach.'),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- To remove a space so that the name/department are readable as separate words.

# Needed By (Date)
- End of sprint (11/20/17)

# Urgency
- Not very.

# Steps to Test

1. Go to the earth home page
2. Inspect the name "Biondi."
3. Make sure the name "Biondi." is separate from "Geophysics."

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- EARTH-633

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)