### PR TITLE
EARTH-841: Change default contact to Josie.

### DIFF
--- a/modules/stanford_news_helper/stanford_news_helper.module
+++ b/modules/stanford_news_helper/stanford_news_helper.module
@@ -17,9 +17,9 @@ function stanford_news_helper_form_node_stanford_news_form_alter(&$form, FormSta
     $subform = &$form['field_s_news_media_contacts']['widget'][0]['subform'];
     $subform['field_highlight_cards_title']['widget'][0]['value']['#default_value'] = 'Media Contacts';
     $card_subform = &$subform['field_p_section_highlight_cards']['widget'][0]['subform'];
-    $card_subform['field_p_highlight_card_title']['widget'][0]['value']['#default_value'] = 'Barbara Buell';
-    $card_subform['field_p_highlight_card_subtitle']['widget'][0]['value']['#default_value'] = '650-723-1771';
-    $card_subform['field_p_highlight_card_desc']['widget'][0]['value']['#default_value'] = 'bbuell@stanford.edu';
+    $card_subform['field_p_highlight_card_title']['widget'][0]['value']['#default_value'] = 'Josie Garthwaite';
+    $card_subform['field_p_highlight_card_subtitle']['widget'][0]['value']['#default_value'] = '650-497-0947';
+    $card_subform['field_p_highlight_card_desc']['widget'][0]['value']['#default_value'] = 'josieg@stanford.edu';
   }
 
   // Check if we are adding a new hero banner and set the variant to tall.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Swap out Barbara for Josie as the default media contact.

# Needed By (Date)
- End of sprint

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Clear caches
3. Create a new news item through the ui
4. Validate that Highlight card media contact is Josie. 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)