### PR TITLE
EARTH-860: Added configuration interface for feeds list.

### DIFF
--- a/modules/stanford_earth_events/src/Form/EventImportersForm.php
+++ b/modules/stanford_earth_events/src/Form/EventImportersForm.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\stanford_earth_events\Form\ListedEventsForm.
+ */
+
+namespace Drupal\stanford_earth_events\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\UrlHelper;
+
+/**
+ * [ListedEventsForm description]
+ */
+class EventImportersForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'stanford_earth_events_listed';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'migrate_plus.migration.events_importer_unlisted',
+      'migrate_plus.migration.events_importer',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $listed = $this->config('migrate_plus.migration.events_importer')->get('source.urls');
+    $unlisted = $this->config('migrate_plus.migration.events_importer_unlisted')->get('source.urls');
+
+    $listed_values = is_array($listed) ? implode($listed, PHP_EOL) : $listed;
+    $unlisted_values = is_array($unlisted) ? implode($unlisted, PHP_EOL) : $unlisted;
+
+    $form['listed_events'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Public or listed events'),
+      '#default_value' => $listed_values,
+      '#description' => $this->t("Enter one feed per line"),
+      '#rows' => 30,
+    );
+
+    $form['unlisted_events'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Private or un-listed events'),
+      '#default_value' => $unlisted_values,
+      '#description' => $this->t("Enter one feed per line"),
+      '#rows' => 30,
+    );
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $listed = array_filter(explode(PHP_EOL, $form_state->getValue('listed_events')));
+    $unlisted = array_filter(explode(PHP_EOL, $form_state->getValue('unlisted_events')));
+    $listed = array_map('trim', $listed);
+    $unlisted = array_map('trim', $unlisted);
+
+    foreach ($listed as $k => $v) {
+      if (empty($v)) {
+        $form_state->setErrorByName('listed_events', $this->t('Cannot have empty lines'));
+      }
+
+      if (!UrlHelper::isValid($v, TRUE)) {
+        $form_state->setErrorByName('listed_events', $this->t('Invalid url included in settings'));
+      }
+
+    }
+
+    foreach ($unlisted as $k => $v) {
+      if (empty($v)) {
+        $form_state->setErrorByName('unlisted_events', $this->t('Cannot have empty lines'));
+      }
+
+      if (!UrlHelper::isValid($v, TRUE)) {
+        $form_state->setErrorByName('unlisted_events', $this->t('Invalid url included in settings'));
+      }
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    $listed = array_filter(explode(PHP_EOL, $form_state->getValue('listed_events')));
+    $unlisted = array_filter(explode(PHP_EOL, $form_state->getValue('unlisted_events')));
+    $listed = array_map('trim', $listed);
+    $unlisted = array_map('trim', $unlisted);
+
+    // Save the new configuration.
+    $this->configFactory->getEditable('migrate_plus.migration.events_importer_unlisted')
+      ->set('source.urls', $unlisted)
+      ->save();
+
+    $this->configFactory->getEditable('migrate_plus.migration.events_importer')
+      ->set('source.urls', array_filter($listed))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/stanford_earth_events/stanford_earth_events.links.menu.yml
+++ b/modules/stanford_earth_events/stanford_earth_events.links.menu.yml
@@ -1,0 +1,6 @@
+stanford_earth_events.importers:
+  title: Event Importer Settings
+  route_name: stanford_earth_events.importers
+  parent: system.admin_config
+  description: 'Configure Event Importers.'
+  weight: -5

--- a/modules/stanford_earth_events/stanford_earth_events.permissions.yml
+++ b/modules/stanford_earth_events/stanford_earth_events.permissions.yml
@@ -1,0 +1,7 @@
+# Since the access to our new custom pages will be granted based on special
+# permissions, we need to define what those permissions are here. This ensures
+# that they are available to enable on the permissions administration pages.
+
+'administer events importers':
+  title: Administer Events Importers
+  description: Allow users to set and change configuration settings.

--- a/modules/stanford_earth_events/stanford_earth_events.routing.yml
+++ b/modules/stanford_earth_events/stanford_earth_events.routing.yml
@@ -1,0 +1,7 @@
+stanford_earth_events.importers:
+  path: '/admin/stanford/events/importers'
+  defaults:
+    _title: 'Public and Private Event feeds lists'
+    _form: '\Drupal\stanford_earth_events\Form\EventImportersForm'
+  requirements:
+    _permission: 'administer events importers'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds configuration forms so that you may change the list of events feeds that are imported.

# Needed By (Date)
- End of sprint

# Urgency
- Low 

# Steps to Test

1. Check out this branch
2. Clear caches.
3. Navigate to /admin/stanford/events/importers
4. Edit and save the form with some good data
5. Run cron to ensure that importers still work. (Check logs)
6. Input invalid data in to the form and submit
7. Ensure validation catches invalid data

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)