### PR TITLE
EARTH-000 Fix for event images being deleted on import 2nd time.

### DIFF
--- a/modules/stanford_earth_events/src/EventSubscriber/EarthEventsEventsSubscriber.php
+++ b/modules/stanford_earth_events/src/EventSubscriber/EarthEventsEventsSubscriber.php
@@ -4,13 +4,11 @@ namespace Drupal\stanford_earth_events\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\migrate\Event\MigrateEvents;
-use Drupal\migrate\Event\MigratePreRowSaveEvent;
 use Drupal\migrate\Event\MigratePostRowSaveEvent;
 use Drupal\migrate\Event\MigrateRowDeleteEvent;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\stanford_earth_events\EarthEventsInfo;
-use Drupal\node\Entity\Node;
 
 /**
  * Class EntityTypeSubscriber.
@@ -54,47 +52,9 @@ class EarthEventsEventsSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      MigrateEvents::PRE_ROW_SAVE => 'migratePreRowSave',
       MigrateEvents::POST_ROW_SAVE => 'migratePostRowSave',
       MigrateEvents::POST_ROW_DELETE => 'migratePostRowDelete',
     ];
-  }
-
-  /**
-   * React to a migrate PRE_ROW_SAVE event.
-   *
-   * Before saving the event, check if there are different feeds already saved
-   * and make sure they continue to be saved in the event node.
-   *
-   * @param \Drupal\migrate\Event\MigratePreRowSaveEvent $event
-   *   Contains information about the migration source row being saved.
-   */
-  public function migratePreRowSave(MigratePreRowSaveEvent $event) {
-    $nid = $event->getRow()->getSourceProperty('nid');
-    if (!empty($nid)) {
-      $existing = Node::load($nid);
-      if (!empty($existing)) {
-        $newDepts = [];
-        $depts = $existing->get('field_s_event_department')->getValue();
-        foreach ($depts as $dept) {
-          if (!empty($dept['target_id'])) {
-            $newDepts[] = $dept['target_id'];
-          }
-        }
-        $newValues = $event->getRow()->getDestinationProperty('field_s_event_department');
-        if (!empty($newValues) && is_array($newValues)) {
-          foreach ($newValues as $newValue) {
-            if (!in_array($newValue, $newDepts, TRUE)) {
-              $newDepts[] = $newValue;
-            }
-          }
-        }
-        if (!empty($newDepts)) {
-          $event->getRow()
-            ->setDestinationProperty('field_s_event_department', $newDepts);
-        }
-      }
-    }
   }
 
   /**

--- a/modules/stanford_earth_events/stanford_earth_events.module
+++ b/modules/stanford_earth_events/stanford_earth_events.module
@@ -12,6 +12,9 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\migrate\Row;
 use Drupal\migrate\Plugin\MigrateSourceInterface;
 use Drupal\stanford_earth_events\EarthEventsInfo;
+use Drupal\node\Entity\Node;
+use Drupal\file\Entity\File;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_entity_delete().
@@ -51,6 +54,7 @@ function stanford_earth_events_cron() {
  */
 function stanford_earth_events_migrate_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
   if (substr($migration->id(), 0, 21) === 'earth_events_importer') {
+
     $event = new EarthEventsInfo($row->getSourceProperty('guid'));
     $event_status = $row->getSourceProperty('field_event_status');
     if ($event_status == 'Unlisted') {
@@ -72,6 +76,30 @@ function stanford_earth_events_migrate_prepare_row(Row $row, MigrateSourceInterf
     if ($event->isValid()) {
       $entityid = $event->entityId();
       if (!empty($entityid)) {
+        $eventNode = Node::load($entityid);
+
+        // If the event node has a media entity image but no image_url in the
+        // event itself, the image will get removed unless we set the source
+        // image_url (field_s_event_image) to the url of the current image.
+        if (empty($row->getSourceProperty('field_s_event_image')) &&
+          !empty($eventNode->get('field_s_event_media')->getValue())) {
+          $mids = $eventNode->get('field_s_event_media')->getValue();
+          foreach ($mids as $mid) {
+            if (!empty($mid['target_id'])) {
+              $mediaEntity = \Drupal::getContainer()->get('entity.manager')
+                ->getStorage('media')->load($mid['target_id']);
+              if (!empty($mediaEntity->get('field_media_image')->getValue())) {
+                $fids = $mediaEntity->get('field_media_image')->getValue();
+                foreach ($fids as $fid) {
+                  $file = File::load($fid['target_id']);
+                  $uri = $file->getFileUri();
+                  //$url = Url::fromUri(file_create_url($uri))->toString();
+                  $row->setSourceProperty('field_s_event_image',$uri);
+                }
+              }
+            }
+          }
+        }
         $row->setSourceProperty('nid', $entityid);
         $row->setDestinationProperty('nid', $entityid);
       }


### PR DESCRIPTION
Hi, Mike,
Would you look at the updated code in stanford_earth_events.module? it's pretty kludgy but it fixes this weird issue where an event without an image gets the default image on the first import but loses it on subsequent updates. Maybe there's a simpler way to do this via the migration configuration, but I don't see it. 
Thanks!
Kassie