### PR TITLE
EARTH-1229: editorial fixes

### DIFF
--- a/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
+++ b/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
@@ -31,7 +31,7 @@ class MosaicBlockDefault extends BlockBase {
         'tiles' => [
           [
             'cite_name' => $this->t('Elsa M. Ordway'),
-            'cite_title' => $this->t('Ph.D.'),
+            'cite_title' => $this->t('PhD \'18'),
             'classes' => 'photo-mosaic--thumbs-down-quote',
             'description' => $this->t('Together, we pursue science and build lifelong bonds.'),
             'image' => [

--- a/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
+++ b/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
@@ -31,7 +31,7 @@ class MosaicBlockDefault extends BlockBase {
         'tiles' => [
           [
             'cite_name' => $this->t('Elsa M. Ordway'),
-            'cite_title' => $this->t('Ph.D. Candidate'),
+            'cite_title' => $this->t('Ph.D.'),
             'classes' => 'photo-mosaic--thumbs-down-quote',
             'description' => $this->t('Together, we pursue science and build lifelong bonds.'),
             'image' => [
@@ -80,7 +80,7 @@ class MosaicBlockDefault extends BlockBase {
             'title' => 'Students',
           ],
           [
-            'cite_name' => $this->t('Biondo Biondi. '),
+            'cite_name' => $this->t('Biondo Biondi'),
             'cite_title' => $this->t('Geophysics Professor.'),
             'classes' => 'photo-mosaic--thumbs-up',
             'description' => $this->t('We discover and teach.'),


### PR DESCRIPTION
# READY FOR REVIEW?

@buttonwillowsix, 
Are there any other changes that need to happen in this block?

# Summary
Makes editorial fixes to the homepage mosaic block
_See ticket:  https://stanfordits.atlassian.net/browse/EARTH-1229_

# Needed By (Date)
- Soon

# Urgency
- Fixes broken stuff on _Prod_


# Steps to Test

- Checkout this branch
- Rebuild cache (`drush cr`)
- On the homepage, verify that 
 1. Ordway is now a PhD (not a candidate)
 2. Biondo Bondi as no period "." at the end of the name.

# Affected Projects or Products
- Earth (https://earth.stanford.edu)

# Associated Issues and/or People
## Related JIRA ticket(s) https://stanfordits.atlassian.net/browse/EARTH-1229


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)