### PR TITLE
EARTH-1300: new faculty and alumni links

### DIFF
--- a/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
+++ b/modules/stanford_earth_mosaic_blocks/src/Plugin/Block/MosaicBlockDefault.php
@@ -126,7 +126,7 @@ class MosaicBlockDefault extends BlockBase {
               ],
             ],
             // 'link' => '/community/faculty',
-            'link' => 'https://pangea.stanford.edu/people/all?tmp_associate_type=regular&tmp_affiliation=all&field_ses_phd_student_value=All&name=',
+            'link' => ' /faculty-research/directory',
             'title' => $this->t('Faculty'),
           ],
           [
@@ -173,7 +173,7 @@ class MosaicBlockDefault extends BlockBase {
               ],
             ],
             // 'link' => '/community/alumni',
-            'link' => 'https://pangea.stanford.edu/alumni',
+            'link' => '/alumni',
             'title' => $this->t('Alumni'),
           ],
         ],


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changing links in the mosaic block

# Needed By (Date)
-Next push

# Urgency
- non-critical

# Steps to Test

1. Go to the mosaic block on the homepage
2. Check that the links to faculty and alumni go to pages on the site, and not pangea

# Affected Projects or Products
- Earth Helper Module

# Associated Issues and/or People
- EARTH-1300

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)