### PR TITLE
EARTH-1562: Remove extra span for the magazine section of logo

### DIFF
--- a/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
+++ b/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
@@ -11,7 +11,7 @@
 <footer id="footer__container">
   <section class="earth-matters-footer visible">
     <div class="earth-matters-footer__logo-container">
-      <span class="earth-matters-footer__logo">{{ 'Stanford Earth Matters'|trans }}<span class="earth-matters-footer__logo-2">{{ 'magazine'|trans }}</span></span>
+      <span class="earth-matters-footer__logo">{{ 'Stanford Earth Matters magazine'|trans }}</span>
       <hr>
     </div>
     <div class="earth-matters-footer__links-container">

--- a/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
+++ b/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
@@ -11,7 +11,9 @@
 <footer id="footer__container">
   <section class="earth-matters-footer visible">
     <div class="earth-matters-footer__logo-container">
-      <span class="earth-matters-footer__logo">{{ 'Stanford Earth Matters magazine'|trans }}</span>
+      <a href="/earth-matters">
+        <span class="earth-matters-footer__logo">{{ 'Stanford Earth Matters magazine'|trans }}</span>
+      </a>
       <hr>
     </div>
     <div class="earth-matters-footer__links-container">


### PR DESCRIPTION
Remove extra span for the magazine section of logo. [EARTH-1562](https://stanfordits.atlassian.net/browse/EARTH-1562)