### PR TITLE
EARTH-1592: Update global footer link

### DIFF
--- a/modules/stanford_earth_contact_footer/templates/block--stanford-earth-contact-footer.html.twig
+++ b/modules/stanford_earth_contact_footer/templates/block--stanford-earth-contact-footer.html.twig
@@ -64,7 +64,7 @@
             <a href="https://www.stanford.edu/site/privacy/" title="{{ "Privacy and cookie policy"|t }}">{{ "Privacy"|t }}</a>
             <a href="https://uit.stanford.edu/security/copyright-infringement" title="{{ "Report alleged copyright infringement"|t }}">{{ "Copyright"|t }}</a>
             <a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="{{ "Ownership and use of Stanford trademarks and images"|t }}">{{ "Trademarks"|t }}</a>
-            <a href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/" title="{{ "Non-discrimination policy"|t }}">{{ "Non-Discrimination"|t }}</a>
+            <a href="https://bulletin.stanford.edu/pages/c7vDgeOuJIfpZe8GKmW3" title="{{ "Non-discrimination policy"|t }}">{{ "Non-Discrimination"|t }}</a>
             <a href="https://www.stanford.edu/site/accessibility" title="{{ "Report web accessibility issues"|t }}">{{ "Accessibility"|t }}</a>
           </span>
         </div>

--- a/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
+++ b/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
@@ -63,7 +63,7 @@
             <a href="https://www.stanford.edu/site/privacy/" title="{{ "Privacy and cookie policy"|t }}">{{ "Privacy"|t }}</a>
             <a href="https://uit.stanford.edu/security/copyright-infringement" title="{{ "Report alleged copyright infringement"|t }}">{{ "Copyright"|t }}</a>
             <a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="{{ "Ownership and use of Stanford trademarks and images"|t }}">{{ "Trademarks"|t }}</a>
-            <a href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/" title="{{ "Non-discrimination policy"|t }}">{{ "Non-Discrimination"|t }}</a>
+            <a href="https://bulletin.stanford.edu/pages/c7vDgeOuJIfpZe8GKmW3" title="{{ "Non-discrimination policy"|t }}">{{ "Non-Discrimination"|t }}</a>
             <a href="https://www.stanford.edu/site/accessibility" title="{{ "Report web accessibility issues"|t }}">{{ "Accessibility"|t }}</a>
           </span>
         </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- TL;DR - what's this PR for?
- Updating the Non-Discriminimation Link in the global footer section of the contact footer and earth matters footer twig templates
- [EARTH-1592](https://stanfordits.atlassian.net/browse/EARTH-1592): Add new Non-Discriminimation Link to Global Footer