### PR TITLE
EARTH-1609: Add Hopkins Marine Station link

### DIFF
--- a/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
+++ b/modules/stanford_earth_matters_footer/templates/block--stanford-earth-matters-footer.html.twig
@@ -22,6 +22,7 @@
           <li><a href="https://earth.stanford.edu/" class="earth-matters-footer__menu-item">{{ 'School of Earth, Energy & Environmental Sciences'|trans }}</a></li>
           <li><a href="https://energy.stanford.edu/" class="earth-matters-footer__menu-item">{{ 'Precourt Institute for Energy'|trans }}</a></li>
           <li><a href="https://woods.stanford.edu/" class="earth-matters-footer__menu-item">{{ 'Stanford Woods Institute for the Environment'|trans }}</a></li>
+          <li><a href="https://hopkinsmarinestation.stanford.edu/" class="earth-matters-footer__menu-item">{{ 'Hopkins Marine Station'|trans }}</a></li>
         </ul>
       </div>
       <div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Hopkins Marine Station to Earth Matters Footer

# Associated Issues and/or People
- [EARTH-1609](https://stanfordits.atlassian.net/browse/EARTH-1609): Add Hopkins Marine Station to Earth Matters Footer